### PR TITLE
Fix match details crash when no data

### DIFF
--- a/L4D2PlayStats.Web/L4D2PlayStats.Web/Controllers/LastMatchesController.cs
+++ b/L4D2PlayStats.Web/L4D2PlayStats.Web/Controllers/LastMatchesController.cs
@@ -34,7 +34,9 @@ public class LastMatchesController(
     public async Task<IActionResult> Details(string start, string end)
     {
         var matches = await matchesService.BetweenAsync(ServerId, start, end);
-        var match = matches.First();
+        var match = matches.FirstOrDefault();
+        if (match == null)
+            return NotFound();
         var statistics = await statisticsService.BetweenAsync(ServerId, start, end);
 
         await LoadAvatarsAsync(matches);
@@ -48,7 +50,9 @@ public class LastMatchesController(
     public async Task<IActionResult> Statistics(string start, string end, string statisticId)
     {
         var matches = await matchesService.BetweenAsync(ServerId, start, end);
-        var match = matches.First();
+        var match = matches.FirstOrDefault();
+        if (match == null)
+            return NotFound();
         var statistics = await statisticsService.BetweenAsync(ServerId, start, end);
         var statistic = statistics.FirstOrDefault(f => f.StatisticId == statisticId);
 


### PR DESCRIPTION
## Summary
- prevent invalid access when match query returns empty

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486120ee84832ea83ca268eb1fc9d2