### PR TITLE
Display message when ranking list is empty

### DIFF
--- a/L4D2PlayStats.Web/L4D2PlayStats.Web/Resources/Views/Home/Index.en-US.resx
+++ b/L4D2PlayStats.Web/L4D2PlayStats.Web/Resources/Views/Home/Index.en-US.resx
@@ -131,4 +131,7 @@
   <data name="ViewPreviousRankings" xml:space="preserve">
     <value>View previous rankings</value>
   </data>
+  <data name="NoRankingMessage" xml:space="preserve">
+    <value>There is no ranking data at the moment. Once a match is played it will be counted here.</value>
+  </data>
 </root>

--- a/L4D2PlayStats.Web/L4D2PlayStats.Web/Resources/Views/Home/Index.es-ES.resx
+++ b/L4D2PlayStats.Web/L4D2PlayStats.Web/Resources/Views/Home/Index.es-ES.resx
@@ -131,4 +131,7 @@
   <data name="ViewPreviousRankings" xml:space="preserve">
     <value>Ver rankings anteriores</value>
   </data>
+  <data name="NoRankingMessage" xml:space="preserve">
+    <value>No existen datos en este momento. Cuando haya una partida se contará aquí.</value>
+  </data>
 </root>

--- a/L4D2PlayStats.Web/L4D2PlayStats.Web/Resources/Views/Home/Index.pt-BR.resx
+++ b/L4D2PlayStats.Web/L4D2PlayStats.Web/Resources/Views/Home/Index.pt-BR.resx
@@ -131,4 +131,7 @@
   <data name="ViewPreviousRankings" xml:space="preserve">
     <value>Ver rankings anteriores</value>
   </data>
+  <data name="NoRankingMessage" xml:space="preserve">
+    <value>Não existem dados no momento. Assim que houver uma partida ela será contabilizada aqui.</value>
+  </data>
 </root>

--- a/L4D2PlayStats.Web/L4D2PlayStats.Web/Views/Home/Index.cshtml
+++ b/L4D2PlayStats.Web/L4D2PlayStats.Web/Views/Home/Index.cshtml
@@ -60,6 +60,14 @@
     @Html.ActionLink(Localizer["ViewPreviousRankings"].Value, "Index", "History")
 </small>
 
+@if (!Model.Ranking.Any())
+{
+    <div class="jumbotron text-center" style="margin-top: 20px">
+        <p>@Localizer["NoRankingMessage"]</p>
+    </div>
+}
+else
+{
 <table class="table table-striped table-hover table-bordered table-condensed" id="table-ranking">
     <thead>
     <tr>
@@ -184,4 +192,5 @@
             </button>
         </div>
     </div>
+}
 }


### PR DESCRIPTION
## Summary
- show message when there are no ranking entries
- localize the message in English, Portuguese and Spanish

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686437720f60832ebbee14607759d1ed